### PR TITLE
add livy auth support

### DIFF
--- a/plugins/dbnd-spark/src/dbnd_spark/livy/livy_spark.py
+++ b/plugins/dbnd-spark/src/dbnd_spark/livy/livy_spark.py
@@ -138,4 +138,4 @@ class LivySparkCtrl(_LivySparkCtrl):
     def get_livy_endpoint(self):
         livy_config = self.task_run.task.spark_engine  # type: LivySparkConfig
         livy_auth = livy_config.auth if livy_config.auth in AUTHS_SUPPORTED else NO_AUTH
-        return Endpoint(livy_config.url, auth=livy_auth)
+        return Endpoint(livy_config.url, auth=livy_auth, username=livy_config.user, password=livy_config.password)

--- a/plugins/dbnd-spark/src/dbnd_spark/livy/livy_spark.py
+++ b/plugins/dbnd-spark/src/dbnd_spark/livy/livy_spark.py
@@ -5,6 +5,7 @@ import six
 from dbnd._core.current import current_task_run
 from dbnd._core.utils.basics.text_banner import TextBanner
 from dbnd._core.utils.http.endpoint import Endpoint
+from dbnd._core.utils.http.constants import AUTHS_SUPPORTED, NO_AUTH
 from dbnd._core.utils.structures import list_of_strings
 from dbnd._vendor.termcolor import colored
 from dbnd_spark.livy.livy_batch import LivyBatchClient
@@ -136,4 +137,5 @@ class LivySparkCtrl(_LivySparkCtrl):
 
     def get_livy_endpoint(self):
         livy_config = self.task_run.task.spark_engine  # type: LivySparkConfig
-        return Endpoint(livy_config.url)
+        livy_auth = livy_config.auth if livy_config.auth in AUTHS_SUPPORTED else NO_AUTH
+        return Endpoint(livy_config.url, auth=livy_auth)

--- a/plugins/dbnd-spark/src/dbnd_spark/livy/livy_spark_config.py
+++ b/plugins/dbnd-spark/src/dbnd_spark/livy/livy_spark_config.py
@@ -24,6 +24,10 @@ class LivySparkConfig(SparkEngineConfig):
         str
     ]
 
+    ignore_ssl_errors = parameter(description="ignore ssl error", default=False)[
+        bool
+    ]
+
     def get_spark_ctrl(self, task_run):
         from dbnd_spark.livy.livy_spark import LivySparkCtrl
 

--- a/plugins/dbnd-spark/src/dbnd_spark/livy/livy_spark_config.py
+++ b/plugins/dbnd-spark/src/dbnd_spark/livy/livy_spark_config.py
@@ -1,5 +1,6 @@
 from dbnd import parameter
 from dbnd_spark.spark_config import SparkEngineConfig
+from dbnd._core.utils.http.constants import NO_AUTH
 
 
 class LivySparkConfig(SparkEngineConfig):
@@ -11,7 +12,15 @@ class LivySparkConfig(SparkEngineConfig):
         str
     ]
 
-    auth = parameter(description="livy auth , support list are None, Kerberos, Basic_Access")[
+    auth = parameter(description="livy auth , support list are None, Kerberos, Basic_Access", default=NO_AUTH)[
+        str
+    ]
+
+    user = parameter(description="livy auth , user", default="")[
+        str
+    ]
+
+    password = parameter(description="livy auth , password", default="")[
         str
     ]
 

--- a/plugins/dbnd-spark/src/dbnd_spark/livy/livy_spark_config.py
+++ b/plugins/dbnd-spark/src/dbnd_spark/livy/livy_spark_config.py
@@ -11,6 +11,10 @@ class LivySparkConfig(SparkEngineConfig):
         str
     ]
 
+    auth = parameter(description="livy auth , support list are None, Kerberos, Basic_Access")[
+        str
+    ]
+
     def get_spark_ctrl(self, task_run):
         from dbnd_spark.livy.livy_spark import LivySparkCtrl
 


### PR DESCRIPTION
Add Livy Auth support on Databand config, currently is default to no auth option for the livy config.
- add option to select auth method (None, Kerberos, Basic_Access)
- add option to ignore verify ssl error