### PR TITLE
Update state of TIs at the end of SingleDagRunJob

### DIFF
--- a/modules/dbnd-airflow/src/dbnd_airflow/dbnd_airflow_main.py
+++ b/modules/dbnd-airflow/src/dbnd_airflow/dbnd_airflow_main.py
@@ -90,6 +90,13 @@ def main(args=None):
         os.environ["KRB5_KTNAME"] = conf.get("kerberos", "keytab")
 
     import argcomplete
+    from dbnd_airflow.scheduler.single_dag_run_job import find_and_kill_zombies
+
+    CLIFactory.subparsers_dict[find_and_kill_zombies.__name__] = {
+        "func": find_and_kill_zombies,
+        "help": "Clean up BackfillJob zombie tasks",
+        "args": tuple(),
+    }
 
     parser = CLIFactory.get_parser()
     argcomplete.autocomplete(parser)

--- a/modules/dbnd-airflow/src/dbnd_airflow/scheduler/single_dag_run_job.py
+++ b/modules/dbnd-airflow/src/dbnd_airflow/scheduler/single_dag_run_job.py
@@ -40,7 +40,8 @@ def _kill_zombies(dag_run, session):
     fail the DR and related unfinished TIs
     """
     logger.info(
-        "Job has ended but the related DagRun is still in state %s - marking it as failed",
+        "Job has ended but the related %s is still in state %s - marking it as failed",
+        dag_run,
         dag_run.state,
     )
     qry = session.query(TI).filter(

--- a/modules/dbnd-airflow/src/dbnd_airflow/scheduler/single_dag_run_job.py
+++ b/modules/dbnd-airflow/src/dbnd_airflow/scheduler/single_dag_run_job.py
@@ -839,7 +839,7 @@ def find_and_kill_zombies(args, session=None):
         session.query(TI).filter(
             TI.dag_id == dr.dag_id,
             TI.execution_date == dr.execution_date,
-            TI.state != State.SUCCESS,
+            TI.state.notin_(END_STATES),
         ).update({TI.state: State.FAILED, TI.end_date: timezone.utcnow()})
         session.merge(dr)
     print("Cleaning done!")

--- a/modules/dbnd-airflow/src/dbnd_airflow/scheduler/single_dag_run_job.py
+++ b/modules/dbnd-airflow/src/dbnd_airflow/scheduler/single_dag_run_job.py
@@ -817,8 +817,7 @@ def find_and_kill_zombies(args, session=None):
         seconds=seconds_from_last_heartbeat
     )
     logger.info(
-        "Cleaning zombie tasks with heartbeat older than: %s",
-        last_expected_heartbeat,
+        "Cleaning zombie tasks with heartbeat older than: %s", last_expected_heartbeat,
     )
 
     # Select BackfillJob that failed or are still running


### PR DESCRIPTION
When the `launcher` task is killed then children task from the dbnd DAG are failed:
<img width="2547" alt="Screenshot 2020-10-06 at 10 10 43" src="https://user-images.githubusercontent.com/9528307/95176944-d9d8a780-07bd-11eb-8164-0f43b30ef581.png">


seems to be working also when the task is killed in the meantime:
<img width="2547" alt="Screenshot 2020-10-06 at 10 29 32" src="https://user-images.githubusercontent.com/9528307/95177774-e4e00780-07be-11eb-84c0-1a15d4c95290.png">
