### PR TITLE
fix attribute error in dbnd_task_as_bash_operator

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,24 +2,29 @@ FROM python:3.6
 
 USER root
 RUN apt-get update
-RUN apt-get install -y gcc unzip
+RUN apt-get install -y gcc unzip vim
 
 COPY ./plugins /dbnd/plugins/
 COPY ./modules /dbnd/modules/
 COPY ./examples /dbnd/examples/
 
-COPY ./setup.cfg /dbnd/modules/dbnd
-COPY ./setup.cfg /dbnd/modules/dbnd-airflow
-COPY ./setup.cfg /dbnd/examples
+COPY ./setup.cfg /dbnd/modules/dbnd/setup.cfg
+COPY ./setup.cfg /dbnd/modules/dbnd-airflow/setup.cfg
+COPY ./setup.cfg /dbnd/examples/setup.cfg
+COPY ./setup.cfg /dbnd/plugins/*/setup.cfg
 
 COPY ./project.cfg /dbnd/
 
 RUN pip install --upgrade pip
 RUN pip install apache-airflow
 
+RUN pip install -e /dbnd/modules/dbnd-airflow[airflow_1_10_12]
 RUN pip install -e /dbnd/modules/dbnd
-RUN pip install -e /dbnd/modules/dbnd-airflow
 RUN pip install -e /dbnd/examples
+RUN pip install -e /dbnd/plugins/dbnd-airflow-auto-tracking
+RUN pip install -e /dbnd/plugins/dbnd-airflow-export
+RUN pip install -e /dbnd/plugins/dbnd-airflow-operator
+RUN pip install -e /dbnd/plugins/dbnd-airflow-versioned-dag
 
 WORKDIR /dbnd
 

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -9,10 +9,11 @@ services:
       - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://postgres:airflow@postgres/airflow
       - AIRFLOW__CORE__PARALLELISM=4
       - AIRFLOW__CORE__EXECUTOR=LocalExecutor
+      - AIRFLOW__CORE__DAGS_FOLDER=/dbnd/examples/src/dbnd_examples/dbnd_airflow
     expose:
       - 8080
     ports:
-      - 8080:8080
+      - "8080:8080"
     volumes:
       - ./modules/:/dbnd/modules/
       - ./plugins/:/dbnd/plugins/

--- a/modules/dbnd-airflow/setup.py
+++ b/modules/dbnd-airflow/setup.py
@@ -13,7 +13,7 @@ version = config["metadata"]["version"]
 
 requirements_for_airflow = [
     "WTForms<2.3.0",  # fixing ImportError: cannot import name HTMLString at 2.3.0
-    "Werkzeug<1.0.0",
+    "Werkzeug<1.0.0,>=0.15.0",
     "cattrs==1.0.0",  # airflow requires ~0.9 but it's py2 incompatible (bug)
     "psycopg2>=2.7.4,<2.8",
 ]
@@ -21,7 +21,7 @@ requirements_for_airflow = [
 setuptools.setup(
     name="dbnd-airflow",
     package_dir={"": "src"},
-    install_requires=["dbnd==" + version],
+    install_requires=["dbnd==" + version, "packaging"],
     extras_require=dict(
         airflow=requirements_for_airflow + ["apache-airflow==1.10.7"],
         airflow_1_10_7=requirements_for_airflow + ["apache-airflow==1.10.7"],

--- a/modules/dbnd-airflow/src/dbnd_airflow/functional/dbnd_cmd_operators.py
+++ b/modules/dbnd-airflow/src/dbnd_airflow/functional/dbnd_cmd_operators.py
@@ -1,10 +1,11 @@
-def dbnd_task_as_bash_operator(task_cls, name=None, cmd_line=None, **kwargs):
+def dbnd_task_as_bash_operator(dbnd_func_proxy, name=None, cmd_line=None, **kwargs):
     from airflow.operators.bash_operator import BashOperator
 
-    task_id = name or "run_%s" % task_cls.task_definition.task_family
+    task_id = name or "run_%s" % dbnd_func_proxy.task_definition.task_family
     cmd_line = cmd_line or ""
     templated_command = "dbnd run {full_task_family} {cmd_line}".format(
-        full_task_family=task_cls.task_definition.full_task_family, cmd_line=cmd_line
+        full_task_family=dbnd_func_proxy.task_cls.task_definition.full_task_family,
+        cmd_line=cmd_line,
     )
     return BashOperator(task_id=task_id, bash_command=templated_command, **kwargs)
 

--- a/modules/dbnd/setup.py
+++ b/modules/dbnd/setup.py
@@ -1,5 +1,14 @@
+from os import path
+
 import setuptools
 
+from setuptools.config import read_configuration
+
+
+BASE_PATH = path.dirname(__file__)
+CFG_PATH = path.join(BASE_PATH, "setup.cfg")
+
+config = read_configuration(CFG_PATH)
 
 # A list of vendored packages
 dbnd_vendors_list = [


### PR DESCRIPTION
DbndFuncProxy does not have `task_definition` attribute, however we can
get to it through `task_cls` property. Also misleading `task_cls` arg name
was changed to `dbnd_func_proxy` to avoid confusion in future