### PR TITLE
hide parameter value in logs and tracking on demand

### DIFF
--- a/modules/dbnd/src/dbnd/_core/parameter/parameter_definition.py
+++ b/modules/dbnd/src/dbnd/_core/parameter/parameter_definition.py
@@ -170,6 +170,7 @@ class ParameterDefinition(object):  # generics are broken: typing.Generic[T]
     parameter_id = attr.ib(default=1)
 
     value_meta_conf = attr.ib(default=None)  # type: ValueMetaConf
+    hidden = attr.ib(default=False)  # type: bool
 
     @property
     def group(self):

--- a/modules/dbnd/src/dbnd/_core/task_ctrl/task_parameters.py
+++ b/modules/dbnd/src/dbnd/_core/task_ctrl/task_parameters.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Tuple, Type
 
-from dbnd._core.configuration.config_value import ConfigValue
 from dbnd._core.parameter.parameter_definition import ParameterDefinition
+from dbnd._core.parameter.parameter_value import ParameterValue
 from dbnd._core.task_ctrl.task_meta import TaskMeta
 
 
@@ -27,7 +27,7 @@ class TaskParameters(object):
 
         return getattr(self.task, param_name)
 
-    def get_param_meta(self, param_name):  # type: (str)->ConfigValue
+    def get_param_meta(self, param_name):  # type: (str) -> ParameterValue
         return self.task_meta._task_params.get_any_param(param_name, None)
 
     def get_params(

--- a/modules/dbnd/src/dbnd/_core/task_ctrl/task_visualiser.py
+++ b/modules/dbnd/src/dbnd/_core/task_ctrl/task_visualiser.py
@@ -158,7 +158,9 @@ class _TaskBannerBuilder(TaskSubCtrl):
             relevant_params.append(p)
 
         for p in relevant_params:
-            value = self.params.get_value(p.name)
+            # TODO: change it to param_meta.value_to_track when we make sure
+            # it'll return correct runtime value
+            value = self.params.get_value(p.name) if not p.hidden else "***"
             param_meta = self.params.get_param_meta(p.name)
             target_config = p.target_config
             if isinstance(value, InMemoryTarget):

--- a/modules/dbnd/src/dbnd/_core/tracking/tracking_info_convertor.py
+++ b/modules/dbnd/src/dbnd/_core/tracking/tracking_info_convertor.py
@@ -242,7 +242,10 @@ def build_task_run_info(task_run):
                 parameter_name=tdp.name,
                 value_origin=safe_short_string(str(value_source), max_value_len=5000),
                 value=safe_short_string(
-                    str(task_params_values.get(tdp.name, value)), max_value_len=5000,
+                    str(task_params_values.get(tdp.name, value))
+                    if not tdp.hidden
+                    else "***",
+                    max_value_len=5000,
                 ),
             )
         )

--- a/modules/dbnd/test_dbnd/parameters/test_hidden_parameter.py
+++ b/modules/dbnd/test_dbnd/parameters/test_hidden_parameter.py
@@ -1,0 +1,34 @@
+from dbnd import task
+from dbnd._core.parameter.parameter_builder import parameter
+from dbnd._core.task_ctrl.task_visualiser import TaskVisualiser
+from dbnd._core.tracking.tracking_info_convertor import build_task_run_info
+
+
+@task
+def t_f(input_=parameter[str](hidden=True)):
+    print("testing...")
+    return "random string"
+
+
+class TestHiddenParameter(object):
+    def test_parameter_value_stays_hidden_in_task_run_info_object(self):
+        my_task = t_f.t("test_string")
+        task_run = my_task.dbnd_run().root_task_run
+
+        task_run_info = build_task_run_info(task_run)
+
+        input_task_param_info = [
+            task_param_info
+            for task_param_info in task_run_info.task_run_params
+            if task_param_info.parameter_name == "input_"
+        ]
+        assert len(input_task_param_info) == 1
+        assert input_task_param_info[0].value == "***"
+
+    def test_parameter_value_stays_hidden_in_banner(self):
+        my_task = t_f.t("test_string")
+        my_task.dbnd_run()
+
+        banner = TaskVisualiser(my_task).banner("some_msg")
+        print(banner)
+        assert "***" in banner and "test_string" not in banner


### PR DESCRIPTION
* add `hidden` attr to `ParameterDefinition`
* add `value_to_track` property to `ParameterValue`
* use `value_to_track` property whenever tracker wants to read `value` of parameter
* fix misleading type hint