### PR TITLE
Put relevant link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ log_metric("r2", r2)
 
 ## Getting Started
 
-See our [documentation](https://dbnd.readme.io/) with examples and quickstart guides to get up and running with DBND.
+See our [documentation](https://docs.databand.ai/docs) with examples and quickstart guides to get up and running with DBND.
 
 ## The Latest and Greatest
 


### PR DESCRIPTION
## Motivation

When I open the documentation's link (https://dbnd.readme.io/) in the `README.md`, it says that the documentation has been moved to the different website (https://docs.databand.ai/docs). The point is illustrated below:

<img width="766" alt="Screenshot 2022-01-25 at 21 36 15" src="https://user-images.githubusercontent.com/22666467/151047227-660a6e85-deae-47a1-aa89-b429f47fcc19.png">


Maybe, it will be better to put relevant link to `README.md`?

