### PR TITLE
Remove unnecessary elevated permission api call

### DIFF
--- a/modules/dbnd/src/dbnd/_core/task_run/task_sync_ctrl.py
+++ b/modules/dbnd/src/dbnd/_core/task_run/task_sync_ctrl.py
@@ -52,7 +52,7 @@ class TaskSyncCtrl(TaskRunCtrl):
         return file.fs.name != FileSystems.local
 
     def _md5(self, local_path):
-        with open(local_path, "rb+") as f:
+        with open(local_path, "rb") as f:
             checksum = hashlib.md5(f.read())  # nosec B324
         return checksum.hexdigest()
 


### PR DESCRIPTION
The '+' requests open for updating (read and write), but the md5 checksum usage is only read. 

This unnecessary write request leads to OSError for permission denial on read-only fs.